### PR TITLE
Minor fixes for v0.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developers may wish to clone the latest version from GitHub and install this loc
 
 ```bash
 git clone https://github.com/open-climate/copa.git
-pip install -e .[dev,docs]
+pip install -e ./copa[dev,docs]
 ```
 
 To execute all tests run: `pytest`

--- a/copa/copa.py
+++ b/copa/copa.py
@@ -25,6 +25,12 @@ def main() -> None:
     are passed (i.e., only the script name is present in sys.argv). Otherwise, defaults 
     to the CLI interface.
     """
+    # Warn about EOL Python versions
+    if sys.version_info < (3, 9):
+        logger.error(f"Python {sys.version_info.major}.{sys.version_info.minor} is end-of-life. Please upgrade to Python 3.10+")
+    elif sys.version_info < (3, 10):
+        logger.warning(f"Python {sys.version_info.major}.{sys.version_info.minor} reaches end-of-life in October 2025. Consider upgrading to Python 3.10+")
+    
     try:
         config = load_toc()
         logger.debug("Configuration loaded successfully")

--- a/copa/core/logging/setup.py
+++ b/copa/core/logging/setup.py
@@ -30,7 +30,7 @@ Note:
 import argparse
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from copa import get_or_create_config_path, TOOL_NAME
 
@@ -62,7 +62,7 @@ def setup_logging(verbosity: int = logging.ERROR, log_to_file: Optional[Path] = 
     console_level = verbosity
     
     # Create handlers list
-    handlers: list[logging.Handler] = []
+    handlers: List[logging.Handler] = []
     
     if log_to_file is None:
         # Console handler only

--- a/copa/core/logging/verbosity.py
+++ b/copa/core/logging/verbosity.py
@@ -9,9 +9,10 @@
 """
 import argparse
 import logging
+from typing import List
 
 
-def get_logging_level(args: list[str]) -> int:
+def get_logging_level(args: List[str]) -> int:
     """Get logging level from command line arguments.
 
     ERROR and CRITICAL levels are always reported. Additional logs can be 

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,1 +1,0 @@
-Ansible is slow to install with pip 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - Architecture: developer-guide/architecture.md
     - Contributing: developer-guide/contributing.md
     - Testing: developer-guide/testing.md
+    - Publishing: developer-guide/publishing.md
   - Reference:
     - CLI Reference: reference/cli.md
     - Configuration Schema: reference/configuration.md

--- a/docs/source/developer-guide/publishing.md
+++ b/docs/source/developer-guide/publishing.md
@@ -1,0 +1,97 @@
+# Publishing to PyPI
+
+This guide covers how to publish copa releases to the Python Package Index (PyPI).
+
+## Prerequisites
+
+1. **PyPI Account**: Create an account at [pypi.org](https://pypi.org)
+2. **API Token**: Generate an API token in your PyPI account settings
+3. **Configure Twine**: Run `python -m twine configure` to set up authentication
+
+## Development Dependencies
+
+Install the required build and publishing tools:
+
+```bash
+pip install -e .[dev]
+```
+
+This installs:
+- `build` - Package building tool
+- `twine` - PyPI upload tool
+- `pytest` - Testing framework
+
+## Release Process
+
+### 1. Update Version
+
+Edit `pyproject.toml` and bump the version number:
+
+```toml
+[project]
+name = "copa"
+version = "0.1.2"  # Update this
+```
+
+### 2. Test Locally
+
+Ensure everything works before publishing:
+
+```bash
+# Install in editable mode
+pip install -e .
+
+# Run tests
+pytest
+
+# Test the CLI
+copa --help
+```
+
+### 3. Build Package
+
+Create distribution files:
+
+```bash
+python -m build
+```
+
+This creates:
+- `dist/copa-X.X.X.tar.gz` (source distribution)
+- `dist/copa-X.X.X-py3-none-any.whl` (wheel)
+
+### 4. Upload to PyPI
+
+```bash
+python -m twine upload dist/*
+```
+
+Enter your PyPI credentials when prompted, or use the configured API token.
+
+## Verification
+
+After publishing, verify the release:
+
+1. Check [pypi.org/project/copa](https://pypi.org/project/copa)
+2. Install from PyPI: `pipx install copa==X.X.X`
+3. Test basic functionality
+
+## Troubleshooting
+
+### Package Name Already Taken
+
+If "copa" is already taken on PyPI, you may need to:
+- Use a different name (e.g., "copa-cli")
+- Contact PyPI support to request the name
+
+### Authentication Issues
+
+- Ensure API token has upload permissions
+- Verify token is configured correctly with `python -m twine configure`
+- Check network connectivity and PyPI status
+
+### Build Errors
+
+- Ensure all files are properly included in `pyproject.toml`
+- Check that imports work correctly
+- Verify package metadata is complete

--- a/docs/source/user-guide/commands.md
+++ b/docs/source/user-guide/commands.md
@@ -18,7 +18,6 @@ copa <command> <subcommand> [options]
 ### Global Options
 
 - `-v, --verbose`: Increase verbosity (can be used multiple times)
-- `-q, --quiet`: Decrease verbosity
 - `--help`: Show help information
 
 ### Verbosity Levels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "copa"
-version = "0.1.1"
+version = "0.1.2"
 description = "Configure, Orchestrate and Provision Applications"
 readme = "README.md"
 authors = [
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "build", "twine"]
 docs = ["mkdocs-material"]
 
 [project.scripts]


### PR DESCRIPTION
- Bump version to 0.1.2 in pyproject.toml
- Add build and twine to dev dependencies for PyPI publishing
- Create publishing guide in developer documentation