### PR TITLE
Add GitHub Actions for docs deployment with custom domain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[docs]
+    
+    - name: Build documentation
+      run: |
+        cd docs
+        mkdocs build
+    
+    - name: Setup Pages
+      if: github.ref == 'refs/heads/main'
+      uses: actions/configure-pages@v3
+    
+    - name: Upload artifact
+      if: github.ref == 'refs/heads/main'
+      uses: actions/upload-pages-artifact@v2
+      with:
+        path: docs/site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Copa Documentation
 docs_dir: source
 site_description: Configure, Orchestrate and Provision Applications
-site_url: https://open-climate.github.io/copa_development
+site_url: https://copa.openclimate.net
 
 repo_name: open-climate/copa_development
 repo_url: https://github.com/open-climate/copa_development

--- a/docs/source/CNAME
+++ b/docs/source/CNAME
@@ -1,0 +1,1 @@
+copa.openclimate.net


### PR DESCRIPTION
  - Add GitHub Actions workflow to build and deploy MkDocs to GitHub Pages
  - Configure custom domain copa.openclimate.net with CNAME file
  - Update site_url in mkdocs.yml to match custom domain
  - Auto-deploy docs on push to main branch